### PR TITLE
feat: add a function to retrieve current network information

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ adenaSDK.getAccount().then((account) => {
 });
 ```
 
+### `getNetwork`
+
+Retrieves network information from the connected wallet.
+
+**Example:**
+
+```
+adenaSDK.getNetwork().then((network) => {
+  console.log('Network:', network);
+});
+```
+
 ### `switchNetwork`
 
 Switches the wallet to a different network.

--- a/packages/sdk/src/core/__mocks__/mock-wallet-provider.ts
+++ b/packages/sdk/src/core/__mocks__/mock-wallet-provider.ts
@@ -17,6 +17,7 @@ export const mockWalletProvider: jest.Mocked<WalletProvider> = {
   isConnected: jest.fn().mockResolvedValue(makeResponseMessage(WalletResponseSuccessType.CONNECTION_SUCCESS)),
   addEstablish: jest.fn().mockResolvedValue(makeResponseMessage(WalletResponseSuccessType.CONNECTION_SUCCESS)),
   getAccount: jest.fn().mockResolvedValue(makeResponseMessage(WalletResponseSuccessType.GET_ACCOUNT_SUCCESS)),
+  getNetwork: jest.fn().mockResolvedValue(makeResponseMessage(WalletResponseSuccessType.GET_NETWORK_SUCCESS)),
   switchNetwork: jest.fn().mockResolvedValue(makeResponseMessage(WalletResponseSuccessType.SWITCH_NETWORK_SUCCESS)),
   addNetwork: jest.fn().mockResolvedValue(makeResponseMessage(WalletResponseSuccessType.ADD_NETWORK_SUCCESS)),
   signTransaction: jest.fn().mockResolvedValue(makeResponseMessage(WalletResponseSuccessType.SIGN_SUCCESS)),
@@ -40,6 +41,8 @@ export const addEstablishFailureMock = makeResponseMessage(WalletResponseFailure
 export const addEstablishRejectMock = makeResponseMessage(WalletResponseRejectType.CONNECTION_REJECTED, false);
 
 export const getAccountSuccessMock = makeResponseMessage(WalletResponseSuccessType.GET_ACCOUNT_SUCCESS);
+
+export const getNetworkSuccessMock = makeResponseMessage(WalletResponseSuccessType.GET_NETWORK_SUCCESS);
 
 export const switchNetworkSuccessMock = makeResponseMessage(WalletResponseSuccessType.SWITCH_NETWORK_SUCCESS);
 

--- a/packages/sdk/src/core/__tests__/methods/get-network.test.ts
+++ b/packages/sdk/src/core/__tests__/methods/get-network.test.ts
@@ -1,0 +1,35 @@
+import { mockWalletProvider } from '../../__mocks__/mock-wallet-provider';
+import { getNetwork } from '../../methods';
+import { WalletResponseSuccessType } from '../../types';
+import { GetNetworkResponse } from '../../types/methods';
+import { makeResponseMessage } from '../../utils';
+
+describe('getNetwork', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call getNetwork and return the response', async () => {
+    const mockResponse: GetNetworkResponse = makeResponseMessage(WalletResponseSuccessType.GET_NETWORK_SUCCESS, {
+      chainId: 'chainId',
+      networkName: 'networkName',
+      addressPrefix: 'g',
+      rpcUrl: 'rpcUrl',
+      indexerUrl: null,
+    });
+
+    mockWalletProvider.getNetwork.mockResolvedValue(mockResponse);
+
+    const response = await getNetwork(mockWalletProvider);
+
+    expect(mockWalletProvider.getNetwork).toHaveBeenCalled();
+    expect(response).toEqual(mockResponse);
+  });
+
+  it('should handle errors when getNetwork fails', async () => {
+    const mockError = new Error('Failed to get network');
+    mockWalletProvider.getNetwork.mockRejectedValue(mockError);
+
+    await expect(getNetwork(mockWalletProvider)).rejects.toThrow('Failed to get network');
+  });
+});

--- a/packages/sdk/src/core/methods/get-network.ts
+++ b/packages/sdk/src/core/methods/get-network.ts
@@ -1,0 +1,6 @@
+import { WalletProvider } from '../providers';
+import { GetNetworkResponse } from '../types/methods';
+
+export const getNetwork = (walletProvider: WalletProvider): Promise<GetNetworkResponse> => {
+  return walletProvider.getNetwork();
+};

--- a/packages/sdk/src/core/methods/index.ts
+++ b/packages/sdk/src/core/methods/index.ts
@@ -5,6 +5,7 @@ export * from './connect';
 export * from './disconnect';
 export * from './get-account';
 export * from './get-connection-state';
+export * from './get-network';
 export * from './is-connected';
 export * from './off-connection-change';
 export * from './on-change-account';

--- a/packages/sdk/src/core/providers/wallet.ts
+++ b/packages/sdk/src/core/providers/wallet.ts
@@ -6,6 +6,7 @@ import {
   BroadcastTransactionOptions,
   BroadcastTransactionResponse,
   GetAccountResponse,
+  GetNetworkResponse,
   IsConnectedResponse,
   OnChangeAccountOptions,
   OnChangeAccountResponse,
@@ -33,6 +34,13 @@ export interface WalletProvider {
    * @returns Original Adena response with the account information
    */
   getAccount: () => Promise<GetAccountResponse>;
+
+  /**
+   * Fetch information about the current connected network
+   * @async
+   * @returns Original Adena response with the network information
+   */
+  getNetwork: () => Promise<GetNetworkResponse>;
 
   /**
    * Switches the Adena network to the given chain ID

--- a/packages/sdk/src/core/types/index.ts
+++ b/packages/sdk/src/core/types/index.ts
@@ -1,4 +1,5 @@
 export * from './account.types';
 export * from './config.types';
+export * from './network.types';
 export * from './transaction.types';
 export * from './wallet.types';

--- a/packages/sdk/src/core/types/methods/get-network.types.ts
+++ b/packages/sdk/src/core/types/methods/get-network.types.ts
@@ -1,0 +1,4 @@
+import { NetworkInfo } from '../network.types';
+import { WalletResponse } from '../wallet.types';
+
+export type GetNetworkResponse = WalletResponse<NetworkInfo>;

--- a/packages/sdk/src/core/types/methods/index.ts
+++ b/packages/sdk/src/core/types/methods/index.ts
@@ -4,6 +4,7 @@ export * from './broadcast-transaction.types';
 export * from './connect.types';
 export * from './disconnect.types';
 export * from './get-account.types';
+export * from './get-network.types';
 export * from './is-connected.types';
 export * from './off-connection-change';
 export * from './on-change-account.types';

--- a/packages/sdk/src/core/types/network.types.ts
+++ b/packages/sdk/src/core/types/network.types.ts
@@ -1,0 +1,7 @@
+export type NetworkInfo = {
+  chainId: string;
+  networkName: string;
+  addressPrefix: string;
+  rpcUrl: string;
+  indexerUrl: string | null;
+};

--- a/packages/sdk/src/core/types/wallet.types.ts
+++ b/packages/sdk/src/core/types/wallet.types.ts
@@ -29,6 +29,7 @@ export type WalletResponseType =
 export enum WalletResponseSuccessType {
   CONNECTION_SUCCESS = 'CONNECTION_SUCCESS',
   GET_ACCOUNT_SUCCESS = 'GET_ACCOUNT',
+  GET_NETWORK_SUCCESS = 'GET_NETWORK',
   SIGN_SUCCESS = 'SIGN_TX',
   ADD_NETWORK_SUCCESS = 'ADD_NETWORK_SUCCESS',
   SWITCH_NETWORK_SUCCESS = 'SWITCH_NETWORK_SUCCESS',
@@ -65,6 +66,7 @@ export enum WalletResponseExecuteType {
   ADD_ESTABLISH = 'ADD_ESTABLISH',
   DO_CONTRACT = 'DO_CONTRACT',
   GET_ACCOUNT = 'GET_ACCOUNT',
+  GET_NETWORK = 'GET_NETWORK',
   SIGN_AMINO = 'SIGN_AMINO',
   SIGN_TX = 'SIGN_TX',
   ADD_NETWORK = 'ADD_NETWORK',
@@ -86,6 +88,12 @@ const WalletSuccessMessageInfo: Record<
     status: WalletResponseStatus.SUCCESS,
     type: WalletResponseSuccessType.GET_ACCOUNT_SUCCESS,
     message: 'Account information has been successfully returned.',
+  },
+  GET_NETWORK: {
+    code: 0,
+    status: WalletResponseStatus.SUCCESS,
+    type: WalletResponseSuccessType.GET_NETWORK_SUCCESS,
+    message: 'Network information has been successfully returned.',
   },
   SIGN_TX: {
     code: 0,
@@ -266,6 +274,12 @@ const WalletExecuteMessageInfo: Record<
     status: WalletResponseStatus.SUCCESS,
     type: WalletResponseExecuteType.GET_ACCOUNT,
     message: 'Get Account Information.',
+  },
+  GET_NETWORK: {
+    code: 0,
+    status: WalletResponseStatus.SUCCESS,
+    type: WalletResponseExecuteType.GET_NETWORK,
+    message: 'Get Network Information.',
   },
   SIGN_AMINO: {
     code: 0,

--- a/packages/sdk/src/providers/adena-wallet/adena-wallet.ts
+++ b/packages/sdk/src/providers/adena-wallet/adena-wallet.ts
@@ -2,7 +2,7 @@ import { Tx } from '@gnolang/tm2-js-client';
 
 import { makeResponseMessage } from '../../core';
 import { WalletProvider } from '../../core/providers';
-import { AccountInfo, WalletResponseFailureType, WalletResponseSuccessType } from '../../core/types';
+import { AccountInfo, NetworkInfo, WalletResponseFailureType, WalletResponseSuccessType } from '../../core/types';
 import {
   AddEstablishOptions,
   AddEstablishResponse,
@@ -11,6 +11,7 @@ import {
   BroadcastTransactionOptions,
   BroadcastTransactionResponse,
   GetAccountResponse,
+  GetNetworkResponse,
   IsConnectedResponse,
   OnChangeAccountOptions,
   OnChangeAccountResponse,
@@ -64,6 +65,14 @@ export class AdenaWalletProvider implements WalletProvider {
     };
 
     return mapResponseByAdenaResponse<AccountInfo>(response, accountInfo);
+  }
+
+  async getNetwork(): Promise<GetNetworkResponse> {
+    const adena = this.getAdena();
+    const response = await adena.GetNetwork();
+    const networkInfo: NetworkInfo = response.data;
+
+    return mapResponseByAdenaResponse<NetworkInfo>(response, networkInfo);
   }
 
   async switchNetwork(options: SwitchNetworkOptions): Promise<SwitchNetworkResponse> {

--- a/packages/sdk/src/providers/adena-wallet/index.ts
+++ b/packages/sdk/src/providers/adena-wallet/index.ts
@@ -1,1 +1,2 @@
 export * from './adena-wallet';
+export * from './types';

--- a/packages/sdk/src/providers/adena-wallet/types/adena.ts
+++ b/packages/sdk/src/providers/adena-wallet/types/adena.ts
@@ -3,6 +3,7 @@ import {
   AdenaAddNetwork,
   AdenaDoContract,
   AdenaGetAccount,
+  AdenaGetNetwork,
   AdenaOnEvent,
   AdenaSignTx,
   AdenaSwitchNetwork,
@@ -13,6 +14,8 @@ export type AdenaWallet = {
   AddEstablish: AdenaAddEstablish;
 
   GetAccount: AdenaGetAccount;
+
+  GetNetwork: AdenaGetNetwork;
 
   // Network
   SwitchNetwork: AdenaSwitchNetwork;

--- a/packages/sdk/src/providers/adena-wallet/types/general.ts
+++ b/packages/sdk/src/providers/adena-wallet/types/general.ts
@@ -36,3 +36,21 @@ export type GetAccountResponseData = {
 type GetAccountResponse = AdenaResponse<GetAccountResponseType, GetAccountResponseData>;
 
 export type AdenaGetAccount = () => Promise<GetAccountResponse>;
+
+enum GetNetworkResponseType {
+  GET_NETWORK_SUCCESS = 'GET_NETWORK_SUCCESS',
+  NO_ACCOUNT = 'NO_ACCOUNT',
+  WALLET_LOCKED = 'WALLET_LOCKED',
+}
+
+export type GetNetworkResponseData = {
+  chainId: string;
+  networkName: string;
+  addressPrefix: string;
+  rpcUrl: string;
+  indexerUrl: string | null;
+};
+
+type GetNetworkResponse = AdenaResponse<GetNetworkResponseType, GetNetworkResponseData>;
+
+export type AdenaGetNetwork = () => Promise<GetNetworkResponse>;

--- a/packages/sdk/src/providers/gno-wallet/gno-wallet.ts
+++ b/packages/sdk/src/providers/gno-wallet/gno-wallet.ts
@@ -15,6 +15,7 @@ import {
   BroadcastTransactionOptions,
   BroadcastTransactionResponse,
   GetAccountResponse,
+  GetNetworkResponse,
   IsConnectedResponse,
   OnChangeAccountResponse,
   OnChangeNetworkResponse,
@@ -87,6 +88,10 @@ export class GnoWalletProvider implements TM2WalletProvider {
       console.log(e);
       return makeResponseMessage(WalletResponseFailureType.NO_ACCOUNT);
     }
+  }
+
+  async getNetwork(): Promise<GetNetworkResponse> {
+    throw new Error('not supported');
   }
 
   async switchNetwork(): Promise<SwitchNetworkResponse> {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines:
https://github.com/onbloc/adena-wallet/blob/main/CONTRIBUTING.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
- feature
- chore
- bug
- style
- cleanup
- documentation
- test
-->
- feature

### What this PR does:

Add a function to retrieve the current network state of the wallet.

From the `getNetwork` function, you can get information such as `chain id`, `rpc url`, `indexer url`, etc.
