### PR TITLE
feat: make RPC endpoint configurable for wallet provider

### DIFF
--- a/packages/sdk/src/core/constants/chains.constant.ts
+++ b/packages/sdk/src/core/constants/chains.constant.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_RPC_URL = "https://rpc.gno.land:443"
+export const DEFAULT_RPC_URL = 'https://rpc.gno.land:443';

--- a/packages/sdk/src/core/constants/chains.constant.ts
+++ b/packages/sdk/src/core/constants/chains.constant.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RPC_URL = "https://rpc.gno.land:443"

--- a/packages/sdk/src/core/providers/tm2-wallet.ts
+++ b/packages/sdk/src/core/providers/tm2-wallet.ts
@@ -2,7 +2,7 @@ import { Wallet as TM2Wallet } from '@gnolang/tm2-js-client';
 import { WalletProvider } from './wallet';
 
 export interface TM2WalletProvider extends WalletProvider {
-  connect(): Promise<boolean>;
+  connect(rpcUrl?: string): Promise<boolean>;
 
   disconnect(): Promise<boolean>;
 

--- a/packages/sdk/src/providers/gno-wallet/gno-wallet.ts
+++ b/packages/sdk/src/providers/gno-wallet/gno-wallet.ts
@@ -29,19 +29,19 @@ import { DEFAULT_RPC_URL } from '../../core/constants/chains.constant';
 
 export class GnoWalletProvider implements TM2WalletProvider {
   protected wallet: TM2Wallet | null;
-  protected rpc: string | null;
+  protected rpcUrl: string | null;
 
   constructor(wallet?: TM2Wallet) {
     this.wallet = wallet || null;
-    this.rpc = null;
+    this.rpcUrl = null;
   }
 
   public getWallet(): TM2Wallet | null {
     return this.wallet;
   }
 
-  async connect(rpc?: string): Promise<boolean> {
-    return this.connectProvider(rpc);
+  async connect(rpcUrl?: string): Promise<boolean> {
+    return this.connectProvider(rpcUrl);
   }
 
   async disconnect(): Promise<boolean> {
@@ -139,12 +139,12 @@ export class GnoWalletProvider implements TM2WalletProvider {
     throw new Error('not supported');
   }
 
-  protected connectProvider(rpc?: string): boolean {
+  protected connectProvider(rpcUrl?: string): boolean {
     if (!this.wallet) {
       return false;
     }
 
-    const provider = new JSONRPCProvider(rpc || DEFAULT_RPC_URL);
+    const provider = new JSONRPCProvider(rpcUrl || DEFAULT_RPC_URL);
     this.wallet.connect(provider);
     return true;
   }

--- a/packages/sdk/src/providers/gno-wallet/gno-wallet.ts
+++ b/packages/sdk/src/providers/gno-wallet/gno-wallet.ts
@@ -25,20 +25,23 @@ import {
 } from '../../core/types/methods';
 import { encodeTransaction } from '../../core/utils/encode.utils';
 import { makeResponseMessage } from '../../core/utils/message.utils';
+import { DEFAULT_RPC_URL } from '../../core/constants/chains.constant';
 
 export class GnoWalletProvider implements TM2WalletProvider {
   protected wallet: TM2Wallet | null;
+  protected rpc: string | null;
 
   constructor(wallet?: TM2Wallet) {
     this.wallet = wallet || null;
+    this.rpc = null;
   }
 
   public getWallet(): TM2Wallet | null {
     return this.wallet;
   }
 
-  async connect(): Promise<boolean> {
-    return this.connectProvider();
+  async connect(rpc?: string): Promise<boolean> {
+    return this.connectProvider(rpc);
   }
 
   async disconnect(): Promise<boolean> {
@@ -136,12 +139,12 @@ export class GnoWalletProvider implements TM2WalletProvider {
     throw new Error('not supported');
   }
 
-  protected connectProvider(): boolean {
+  protected connectProvider(rpc?: string): boolean {
     if (!this.wallet) {
       return false;
     }
 
-    const provider = new JSONRPCProvider('https://rpc.gno.land:443');
+    const provider = new JSONRPCProvider(rpc || DEFAULT_RPC_URL);
     this.wallet.connect(provider);
     return true;
   }


### PR DESCRIPTION
### What type of PR is this?
- feature
### What this PR does:
- Make RPC endpoint configurable in GnoWalletProvider to support dynamic RPC URLs
### Changes:
- Add RPC parameter to connect and connectProvider methods
- Initialize RPC field with null value in constructor
- Import and utilize DEFAULT_RPC_URL as fallback option
- Replace hardcoded RPC URL with configurable parameter