### PR TITLE
fix: Handling cases where social login is reconnected

### DIFF
--- a/packages/sdk/src/providers/gno-wallet/gno-social-wallet.ts
+++ b/packages/sdk/src/providers/gno-wallet/gno-social-wallet.ts
@@ -120,6 +120,27 @@ export class GnoSocialWalletProvider extends GnoWalletProvider {
         ...(this.extraLoginOptions && { extraLoginOptions: this.extraLoginOptions }),
       };
 
+      if (this.web3auth.connected) {
+        const userInfo = await this.web3auth.getUserInfo();
+        const currentLoginType = userInfo.typeOfLogin;
+
+        if (currentLoginType !== this.socialType) {
+          const networks = [...this.networks];
+          await this.disconnect();
+
+          this.setNetworks(networks);
+          this.web3auth = await this.initializeWeb3Auth();
+        } else {
+          const privateKey = await this.requestPrivateKey();
+          const privateKeyBytes = hexToUint8Array(privateKey);
+          const wallet = await GnoWallet.fromPrivateKey(privateKeyBytes, {
+            addressPrefix: this.currentNetwork.addressPrefix,
+          })
+          this.wallet = wallet;
+          return this.connectProvider()
+        }
+      }
+
       const provider = await this.web3auth.connectTo(WALLET_ADAPTERS.AUTH, connectOptions);
 
       if (!provider) {

--- a/packages/sdk/src/providers/gno-wallet/gno-social-wallet.ts
+++ b/packages/sdk/src/providers/gno-wallet/gno-social-wallet.ts
@@ -135,9 +135,9 @@ export class GnoSocialWalletProvider extends GnoWalletProvider {
           const privateKeyBytes = hexToUint8Array(privateKey);
           const wallet = await GnoWallet.fromPrivateKey(privateKeyBytes, {
             addressPrefix: this.currentNetwork.addressPrefix,
-          })
+          });
           this.wallet = wallet;
-          return this.connectProvider()
+          return this.connectProvider();
         }
       }
 


### PR DESCRIPTION
### What type of PR is this?
- bug

### What this PR does:
- WalletLoginError due to duplicate connection attempts
  - Error "Already connected"
- Added connected status check logic before connecting social-wallet